### PR TITLE
Removes is_vec3 and is_vec4 

### DIFF
--- a/src/scripts/scr_catspeak_builtins/scr_catspeak_builtins.gml
+++ b/src/scripts/scr_catspeak_builtins/scr_catspeak_builtins.gml
@@ -254,9 +254,7 @@ function __catspeak_init_builtins() {
         "is_real", is_real,
         "is_string", is_string,
         "is_struct", is_struct,
-        "is_undefined", is_undefined,
-        "is_vec3", is_vec3,
-        "is_vec4", is_vec4
+        "is_undefined", is_undefined
     );
     catspeak_add_constant(
         "null", pointer_null,


### PR DESCRIPTION
Very recently in 2023.2.0, `is_vec3`, `is_vec4` and is_matrix was removed. Catspeak still references `is_vec3` and `is_vec4`, so this PR just removes those two type checks.