### PR TITLE
Re: Removes is_vec3 and is_vec4

### DIFF
--- a/src/scripts/scr_catspeak_builtins/scr_catspeak_builtins.gml
+++ b/src/scripts/scr_catspeak_builtins/scr_catspeak_builtins.gml
@@ -254,9 +254,7 @@ function __catspeak_init_builtins() {
         "is_real", is_real,
         "is_string", is_string,
         "is_struct", is_struct,
-        "is_undefined", is_undefined,
-        "is_vec3", is_vec3,
-        "is_vec4", is_vec4
+        "is_undefined", is_undefined
     );
     catspeak_add_constant(
         "null", pointer_null,


### PR DESCRIPTION
Like previous PR #39, but pushed to main as per request. (Also made a separate branch for this as I didn't want to run into a similar edge case from before... lol)