### PR TITLE
Dev 3.0.0 - Set/get Catspeak function self/global

### DIFF
--- a/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
+++ b/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
@@ -129,14 +129,14 @@ function CatspeakGMLCompiler(asg, interface=undefined) constructor {
             self_ = selfInst;
         });
         f.setGlobals = method(sharedData, function (globalInst) {
-            if (CATSPEAK_DEBUG_MODE && globalInst != undefined) {
+            if (CATSPEAK_DEBUG_MODE) {
                 __catspeak_check_arg("globalInst", globalInst,
                         __catspeak_is_withable, "struct");
             }
 
             globals = globalInst;
         });
-        f.getSelf = method(sharedData, function () { return self_ });
+        f.getSelf = method(sharedData, function () { return self_ ?? globals });
         f.getGlobals = method(sharedData, function () { return globals });
     };
 

--- a/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
+++ b/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
@@ -50,6 +50,17 @@ test_add(function () : Test("engine-self-inst") constructor {
     var gmlFunc = engine.compileGML(asg);
     var inst = instance_create_depth(0, 0, 0, obj_unit_test_inst);
     gmlFunc.setSelf(inst);
-    assertEq(gmlFunc(), inst);
+    assertEq(inst, gmlFunc());
     instance_destroy(inst);
+});
+
+test_add(function () : Test("engine-global-shared") constructor {
+    var engine = new CatspeakEnvironment();
+    var fA = engine.compileGML(engine.parseString(@'globalvar = 1;'));
+    var fB = engine.compileGML(engine.parseString(@'globalvar'));
+    var s = { };
+    fA.setGlobals(s);
+    fB.setGlobals(s);
+    fA();
+    assertEq(1, fB());
 });

--- a/src-lts/scripts/scr_testing_scratchpad/scr_testing_scratchpad.gml
+++ b/src-lts/scripts/scr_testing_scratchpad/scr_testing_scratchpad.gml
@@ -9,7 +9,7 @@ if (os_browser != browser_not_a_browser) {
 
 catspeak_force_init();
 
-var runExperiment = "compiler-6";
+var runExperiment = "none";
 #macro TEST_EXPERIMENT if runExperiment ==
 
 TEST_EXPERIMENT "lexer" {


### PR DESCRIPTION
Adds the following methods to compiled Catspeak functions:
 - `.getSelf()` - Returns the self defined by `setSelf`, or the global context if none exists.
 - `.setGlobals(struct_or_instance)` - Sets the underlying global struct to use.
 - `.getGlobals()` - Returns the global struct defined by `setGlobals`.