### PR TITLE
Dev 3.0.0 - Statement terminator improvements

### DIFF
--- a/src-lts/scripts/scr_catspeak_parser/scr_catspeak_parser.gml
+++ b/src-lts/scripts/scr_catspeak_parser/scr_catspeak_parser.gml
@@ -71,7 +71,7 @@ function CatspeakParser(lexer, builder) constructor {
     static __parseStatement = function () {
         var result;
         var peeked = lexer.peek();
-        if (peeked == CatspeakToken.BREAK_LINE) {
+        if (peeked == CatspeakToken.SEMICOLON) {
             lexer.next();
             return;
         } else if (peeked == CatspeakToken.LET) {
@@ -111,7 +111,7 @@ function CatspeakParser(lexer, builder) constructor {
             peeked = lexer.peek();
             var value;
             if (
-                peeked == CatspeakToken.BREAK_LINE ||
+                peeked == CatspeakToken.SEMICOLON ||
                 peeked == CatspeakToken.BRACE_RIGHT
             ) {
                 value = asg.createValue(undefined, lexer.getLocation());
@@ -127,7 +127,7 @@ function CatspeakParser(lexer, builder) constructor {
             peeked = lexer.peek();
             var value;
             if (
-                peeked == CatspeakToken.BREAK_LINE ||
+                peeked == CatspeakToken.SEMICOLON ||
                 peeked == CatspeakToken.BRACE_RIGHT
             ) {
                 value = asg.createValue(undefined, lexer.getLocation());
@@ -572,7 +572,7 @@ function CatspeakParser(lexer, builder) constructor {
         var peeked = lexer.peek();
         if (peeked == CatspeakToken.EOF) {
             return "end of file";
-        } else if (peeked == CatspeakToken.BREAK_LINE) {
+        } else if (peeked == CatspeakToken.SEMICOLON) {
             return "line break ';'";
         }
         return "token '" + lexer.getLexeme() + "' (" + string() + ")";

--- a/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
+++ b/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
@@ -75,3 +75,17 @@ test_add(function () : Test("engine-delete-keyword") constructor {
     assertEq("fun", lexer.getValue());
     buffer_delete(buff);
 });
+
+test_add(function () : Test("engine-struct-not-terminated") constructor {
+    var engine = new CatspeakEnvironment();
+    var asg = engine.parseString(@'
+        return {
+            foo: "bar",
+            a_number: 0,
+            a_string: "Hello World!"
+        }
+    ');
+    var func = engine.compileGML(asg);
+    var result = func();
+    show_message(json_stringify(result));
+});

--- a/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
+++ b/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
@@ -87,5 +87,25 @@ test_add(function () : Test("engine-struct-not-terminated") constructor {
     ');
     var func = engine.compileGML(asg);
     var result = func();
-    show_message(json_stringify(result));
+    assertEq(result, { foo : "bar", a_number : 0, a_string : "Hello World!" });
+});
+
+test_add(function () : Test("engine-function-brace-style") constructor {
+    var engine = new CatspeakEnvironment();
+    var fA = engine.compileGML(engine.parseString(@'
+        main = fun()
+        {
+            return "hi"
+        }
+    '));
+    var fB = engine.compileGML(engine.parseString(@'
+        main = fun() {
+            return "hi"
+        }
+    '));
+    fA();
+    fB();
+    assertEq(fA.getGlobals().main(), fB.getGlobals().main());
+    assertEq("hi", fA.getGlobals().main());
+    assertEq("hi", fB.getGlobals().main());
 });

--- a/src-lts/scripts/scr_testing_framework/scr_testing_framework.gml
+++ b/src-lts/scripts/scr_testing_framework/scr_testing_framework.gml
@@ -19,6 +19,7 @@ function test_stats() {
         totalFailed : 0,
         totalActive : 0,
         totalFatal : 0,
+        n : 1,
         testQueue : ds_queue_create(),
     };
     return stats;
@@ -28,7 +29,7 @@ function Test(name) constructor {
     show_debug_message("RUNNING TEST " + string(name));
 
     var stats = test_stats();
-    self.number = stats.total;
+    self.number = stats.n; stats.n += 1;
     self.name = __cat(name);
     self.fails = [];
     self.automatic = true;

--- a/src-lts/scripts/scr_testing_lexer_keyword/scr_testing_lexer_keyword.gml
+++ b/src-lts/scripts/scr_testing_lexer_keyword/scr_testing_lexer_keyword.gml
@@ -14,7 +14,7 @@ test_add(function () : TestLexerToken("lexer-keyword-colon",
 ) constructor { });
 
 test_add(function () : TestLexerToken("lexer-keyword-break-line",
-    CatspeakToken.BREAK_LINE, ";", ";"
+    CatspeakToken.SEMICOLON, ";", ";"
 ) constructor { });
 
 test_add(function () : TestLexerToken("lexer-keyword-dot",
@@ -22,7 +22,7 @@ test_add(function () : TestLexerToken("lexer-keyword-dot",
 ) constructor { });
 
 test_add(function () : TestLexerToken("lexer-keyword-continue-line",
-    CatspeakToken.CONTINUE_LINE, "...", "..."
+    CatspeakToken.WHITESPACE, "...", "..."
 ) constructor { });
 
 test_add(function () : TestLexerToken("lexer-keyword-do",

--- a/src-lts/scripts/scr_testing_lexer_misc/scr_testing_lexer_misc.gml
+++ b/src-lts/scripts/scr_testing_lexer_misc/scr_testing_lexer_misc.gml
@@ -58,15 +58,12 @@ test_add(function () : TestLexerTokenStream("lexer-misc-example-2",
     '
 ) constructor {
     checkTokens(
-        CatspeakToken.BREAK_LINE,
         CatspeakToken.IDENT,
         CatspeakToken.ASSIGN,
         CatspeakToken.VALUE,
-        CatspeakToken.BREAK_LINE,
         CatspeakToken.IDENT,
         CatspeakToken.ASSIGN,
         CatspeakToken.VALUE,
-        CatspeakToken.BREAK_LINE,
         CatspeakToken.WHILE,
         CatspeakToken.PAREN_LEFT,
         CatspeakToken.IDENT,
@@ -77,18 +74,14 @@ test_add(function () : TestLexerTokenStream("lexer-misc-example-2",
         CatspeakToken.IDENT,
         CatspeakToken.PAREN_LEFT,
         CatspeakToken.PAREN_RIGHT,
-        CatspeakToken.BREAK_LINE,
         CatspeakToken.IDENT,
         CatspeakToken.ASSIGN,
         CatspeakToken.IDENT,
         CatspeakToken.PLUS,
         CatspeakToken.VALUE,
-        CatspeakToken.BREAK_LINE,
         CatspeakToken.BRACE_RIGHT,
-        CatspeakToken.BREAK_LINE,
         CatspeakToken.RETURN,
         CatspeakToken.IDENT,
-        CatspeakToken.BREAK_LINE
     )
 });
 
@@ -108,8 +101,17 @@ test_add(function () : TestLexerTokenStream("lexer-misc-example-3",
     '
 ) constructor {
     checkTokens(
-        CatspeakToken.BREAK_LINE,
+        CatspeakToken.SEMICOLON,
+        CatspeakToken.SEMICOLON,
+        CatspeakToken.SEMICOLON,
+        CatspeakToken.SEMICOLON,
+        CatspeakToken.SEMICOLON,
+        CatspeakToken.SEMICOLON,
         CatspeakToken.IDENT,
-        CatspeakToken.BREAK_LINE,
+        CatspeakToken.SEMICOLON,
+        CatspeakToken.SEMICOLON,
+        CatspeakToken.SEMICOLON,
+        CatspeakToken.SEMICOLON,
+        CatspeakToken.SEMICOLON
     )
 });

--- a/src-lts/scripts/scr_testing_lexer_whitespace/scr_testing_lexer_whitespace.gml
+++ b/src-lts/scripts/scr_testing_lexer_whitespace/scr_testing_lexer_whitespace.gml
@@ -26,7 +26,7 @@ test_add(function () : TestLexerToken("lexer-whitespace-tab",
 ) constructor { });
 
 test_add(function () : TestLexerToken("lexer-whitespace-line-feed",
-    CatspeakToken.BREAK_LINE, "\n", "\n"
+    CatspeakToken.WHITESPACE, "\n", "\n"
 ) constructor { });
 
 test_add(function () : TestLexerToken("lexer-whitespace-vtab",
@@ -38,7 +38,7 @@ test_add(function () : TestLexerToken("lexer-whitespace-form-feed",
 ) constructor { });
 
 test_add(function () : TestLexerToken("lexer-whitespace-carriage-return",
-    CatspeakToken.BREAK_LINE, "\r", "\r"
+    CatspeakToken.WHITESPACE, "\r", "\r"
 ) constructor { });
 
 test_add(function () : TestLexerToken("lexer-whitespace-next-line",
@@ -46,22 +46,22 @@ test_add(function () : TestLexerToken("lexer-whitespace-next-line",
 ) constructor { });
 
 test_add(function () : TestLexerToken("lexer-whitespace-break-line",
-    CatspeakToken.BREAK_LINE, ";", ";"
+    CatspeakToken.SEMICOLON, ";", ";"
 ) constructor { });
 
 test_add(function () : TestLexerToken("lexer-whitespace-continue-line",
-    CatspeakToken.CONTINUE_LINE, "...", "..."
+    CatspeakToken.WHITESPACE, "...", "..."
 ) constructor { });
 
 test_add(function () : TestLexerToken("lexer-whitespace-comment",
     CatspeakToken.COMMENT, "-- hello world", "-- hello world"
 ) constructor { });
 
-test_add(function () : Test("lexer-whitespace-semicolon-insertion") constructor {
+test_add(function () : Test("lexer-whitespace-legacy-line-continue") constructor {
     var buff = __catspeak_create_buffer_from_string(@'...
         let a = (
             1,
-            2, ... ;
+            2, ...
             3,
         )...
 ... ...
@@ -70,7 +70,7 @@ test_add(function () : Test("lexer-whitespace-semicolon-insertion") constructor 
     var token;
     do {
         token = lexer.next();
-        assertNeq(CatspeakToken.BREAK_LINE, token);
+        assertNeq(CatspeakToken.SEMICOLON, token);
     } until (token == CatspeakToken.EOF);
     buffer_delete(buff);
 });


### PR DESCRIPTION
Updates the way Catspeak handles newlines and the `;` syntax for statement termination. Turns the `...` syntax into whitespace for compatibility for now.