### PR TITLE
Dev 3.0.0 - Shared globals

### DIFF
--- a/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
+++ b/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
@@ -25,14 +25,14 @@ function __catspeak_timeout_check(t) {
 ///
 /// @param {Any} val
 function __catspeak_is_withable(val) {
-	if (is_struct(val)) {
-		return true;
-	}
-	var isInst = false;
-	try {
-		isInst = !object_exists(val) && instance_exists(val);
-	} catch (_) { }
-	return isInst;
+    if (is_struct(val)) {
+        return true;
+    }
+    var isInst = false;
+    try {
+        isInst = !object_exists(val) && instance_exists(val);
+    } catch (_) { }
+    return isInst;
 }
 
 /// Consumes an abstract syntax graph and converts it into a callable GML

--- a/src-lts/scripts/scr_catspeak_environment/scr_catspeak_environment.gml
+++ b/src-lts/scripts/scr_catspeak_environment/scr_catspeak_environment.gml
@@ -6,6 +6,30 @@
 function CatspeakEnvironment() constructor {
     self.keywords = undefined;
     self.interface = undefined;
+    self.sharedGlobal = undefined;
+
+    /// Enables the shared global feature on this Catspeak environment. This
+    /// forces all compiled programs to share the same global variable scope.
+    ///
+    /// Typically this should not be enabled, but it can be useful for REPL
+    /// (Read-Eval-Print-Loop) style command consoles, where variables persist
+    /// between commands.
+    ///
+    /// Returns the shared global struct if this feature is enabled, or
+    /// `undefined` if the feature is disabled.
+    ///
+    /// @param {Bool} [enabled]
+    ///   Whether to enable this feature. Defaults to `true`.
+    ///
+    /// @return {Struct}
+    static enableSharedGlobal = function (enabled=true) {
+         if (CATSPEAK_DEBUG_MODE) {
+            __catspeak_check_arg("enabled", enabled, is_numeric);
+        }
+
+        sharedGlobal = enabled ? { } : undefined;
+        return sharedGlobal;
+    };
 
     /// Applies list of presets to this Catspeak environment. These changes
     /// cannot be undone, so only choose presets you really need.
@@ -15,7 +39,7 @@ function CatspeakEnvironment() constructor {
     ///
     /// @param {Enum.CatspeakPreset} ...
     ///   Additional preset arguments.
-    static applyPreset = function() {
+    static applyPreset = function () {
         for (var i = 0; i < argument_count; i += 1) {
             var presetFunc = __catspeak_preset_get(argument[i]);
             presetFunc(self);
@@ -127,6 +151,10 @@ function CatspeakEnvironment() constructor {
         do {
             result = compiler.update();
         } until (result != undefined);
+        if (sharedGlobal != undefined) {
+            // patch global
+            result.setGlobals(sharedGlobal);
+        }
         return result;
     };
 

--- a/src-lts/scripts/scr_catspeak_environment/scr_catspeak_environment.gml
+++ b/src-lts/scripts/scr_catspeak_environment/scr_catspeak_environment.gml
@@ -7,6 +7,129 @@ function CatspeakEnvironment() constructor {
     self.keywords = undefined;
     self.interface = undefined;
 
+    /// Applies list of presets to this Catspeak environment. These changes
+    /// cannot be undone, so only choose presets you really need.
+    ///
+    /// @param {Enum.CatspeakPreset} preset
+    ///   The preset type to apply.
+    ///
+    /// @param {Enum.CatspeakPreset} ...
+    ///   Additional preset arguments.
+    static applyPreset = function() {
+        for (var i = 0; i < argument_count; i += 1) {
+            var presetFunc = __catspeak_preset_get(argument[i]);
+            presetFunc(self);
+        }
+    };
+
+    /// Creates a new [CatspeakLexer] from the supplied buffer, overriding
+    /// the keyword database if one exists for this [CatspeakEngine].
+    ///
+    /// NOTE: The lexer does not take ownership of this buffer, but it may
+    ///       mutate it so beware. Therefore you should make sure to delete
+    ///       the buffer once parsing is complete.
+    ///
+    /// @param {Id.Buffer} buff
+    ///   The ID of the GML buffer to use.
+    ///
+    /// @param {Real} [offset]
+    ///   The offset in the buffer to start parsing from. Defaults to 0.
+    ///
+    /// @param {Real} [size]
+    ///   The length of the buffer input. Any characters beyond this limit
+    ///   will be treated as the end of the file. Defaults to `infinity`.
+    ///
+    /// @return {Struct.CatspeakLexer}
+    static tokenise = function (buff, offset=undefined, size=undefined) {
+        // CatspeakLexer() will do argument validation
+        return new CatspeakLexer(buff, offset, size, keywords);
+    };
+
+    /// Parses a buffer containing a Catspeak program into a bespoke format
+    /// understood by Catpskeak. Overrides the keyword database if one exists
+    /// for this [CatspeakEngine].
+    ///
+    /// NOTE: The parser does not take ownership of this buffer, but it may
+    ///       mutate it so beware. Therefore you should make sure to delete
+    ///       the buffer once parsing is complete.
+    ///
+    /// @param {Id.Buffer} buff
+    ///   The ID of the GML buffer to use.
+    ///
+    /// @param {Real} [offset]
+    ///   The offset in the buffer to start parsing from. Defaults to 0.
+    ///
+    /// @param {Real} [size]
+    ///   The length of the buffer input. Any characters beyond this limit
+    ///   will be treated as the end of the file. Defaults to `infinity`.
+    ///
+    /// @return {Struct.CatspeakLexer}
+    static parse = function (buff, offset=undefined, size=undefined) {
+        // tokenise() will do argument validation
+        var lexer = tokenise(buff, offset, size);
+        var builder = new CatspeakASGBuilder();
+        var parser = new CatspeakParser(lexer, builder);
+        var moreToParse;
+        do {
+            moreToParse = parser.update();
+        } until (!moreToParse);
+        return builder.get();
+    };
+
+    /// Similar to [parse], except a string is used instead of a buffer.
+    ///
+    /// @param {String} src
+    ///   The string containing Catspeak source code to parse.
+    ///
+    /// @return {Struct.CatspeakLexer}
+    static parseString = function (src) {
+        var buff = __catspeak_create_buffer_from_string(src);
+        return Catspeak.parse(buff);
+    };
+
+    /// Similar to [parse], except it will pass the responsibility of
+    /// parsing to this sessions async handler.
+    ///
+    /// NOTE: The async handler can be customised, and therefore any
+    ///       third-party handlers are not guaranteed to finish within a
+    ///       reasonable time.
+    ///
+    /// NOTE: The parser does not take ownership of this buffer, but it may
+    ///       mutate it so beware. Therefore you should make sure to delete
+    ///       the buffer once parsing is complete.
+    ///
+    /// @param {Id.Buffer} buff
+    ///   The ID of the GML buffer to use.
+    ///
+    /// @param {Real} [offset]
+    ///   The offset in the buffer to start parsing from. Defaults to 0.
+    ///
+    /// @param {Real} [size]
+    ///   The length of the buffer input. Any characters beyond this limit
+    ///   will be treated as the end of the file. Defaults to `infinity`.
+    ///
+    /// @return {Struct.Future}
+    static parseAsync = function (buff, offset=undefined, size=undefined) {
+        __catspeak_error_unimplemented("async-parsing");
+    };
+
+    /// Compiles a syntax graph into a GML function. See the [parse] function
+    /// for how to generate a syntax graph from a Catspeak script.
+    ///
+    /// @param {Struct} asg
+    ///   The syntax graph to convert into a GML function.
+    ///
+    /// @return {Function}
+    static compileGML = function (asg) {
+        // CatspeakGMLCompiler() will do argument validation
+        var compiler = new CatspeakGMLCompiler(asg, interface);
+        var result;
+        do {
+            result = compiler.update();
+        } until (result != undefined);
+        return result;
+    };
+
     /// Used to change the string representation of a Catspeak keyword.
     ///
     /// @param {String} currentName
@@ -195,129 +318,6 @@ function CatspeakEnvironment() constructor {
                 variable_struct_remove(interface_, name);
             }
         }
-    };
-
-    /// Applies list of presets to this Catspeak environment. These changes
-    /// cannot be undone, so only choose presets you really need.
-    ///
-    /// @param {Enum.CatspeakPreset} preset
-    ///   The preset type to apply.
-    ///
-    /// @param {Enum.CatspeakPreset} ...
-    ///   Additional preset arguments.
-    static applyPreset = function() {
-        for (var i = 0; i < argument_count; i += 1) {
-            var presetFunc = __catspeak_preset_get(argument[i]);
-            presetFunc(self);
-        }
-    };
-
-    /// Creates a new [CatspeakLexer] from the supplied buffer, overriding
-    /// the keyword database if one exists for this [CatspeakEngine].
-    ///
-    /// NOTE: The lexer does not take ownership of this buffer, but it may
-    ///       mutate it so beware. Therefore you should make sure to delete
-    ///       the buffer once parsing is complete.
-    ///
-    /// @param {Id.Buffer} buff
-    ///   The ID of the GML buffer to use.
-    ///
-    /// @param {Real} [offset]
-    ///   The offset in the buffer to start parsing from. Defaults to 0.
-    ///
-    /// @param {Real} [size]
-    ///   The length of the buffer input. Any characters beyond this limit
-    ///   will be treated as the end of the file. Defaults to `infinity`.
-    ///
-    /// @return {Struct.CatspeakLexer}
-    static tokenise = function (buff, offset=undefined, size=undefined) {
-        // CatspeakLexer() will do argument validation
-        return new CatspeakLexer(buff, offset, size, keywords);
-    };
-
-    /// Parses a buffer containing a Catspeak program into a bespoke format
-    /// understood by Catpskeak. Overrides the keyword database if one exists
-    /// for this [CatspeakEngine].
-    ///
-    /// NOTE: The parser does not take ownership of this buffer, but it may
-    ///       mutate it so beware. Therefore you should make sure to delete
-    ///       the buffer once parsing is complete.
-    ///
-    /// @param {Id.Buffer} buff
-    ///   The ID of the GML buffer to use.
-    ///
-    /// @param {Real} [offset]
-    ///   The offset in the buffer to start parsing from. Defaults to 0.
-    ///
-    /// @param {Real} [size]
-    ///   The length of the buffer input. Any characters beyond this limit
-    ///   will be treated as the end of the file. Defaults to `infinity`.
-    ///
-    /// @return {Struct.CatspeakLexer}
-    static parse = function (buff, offset=undefined, size=undefined) {
-        // tokenise() will do argument validation
-        var lexer = tokenise(buff, offset, size);
-        var builder = new CatspeakASGBuilder();
-        var parser = new CatspeakParser(lexer, builder);
-        var moreToParse;
-        do {
-            moreToParse = parser.update();
-        } until (!moreToParse);
-        return builder.get();
-    };
-
-    /// Similar to [parse], except a string is used instead of a buffer.
-    ///
-    /// @param {String} src
-    ///   The string containing Catspeak source code to parse.
-    ///
-    /// @return {Struct.CatspeakLexer}
-    static parseString = function (src) {
-        var buff = __catspeak_create_buffer_from_string(src);
-        return Catspeak.parse(buff);
-    };
-
-    /// Similar to [parse], except it will pass the responsibility of
-    /// parsing to this sessions async handler.
-    ///
-    /// NOTE: The async handler can be customised, and therefore any
-    ///       third-party handlers are not guaranteed to finish within a
-    ///       reasonable time.
-    ///
-    /// NOTE: The parser does not take ownership of this buffer, but it may
-    ///       mutate it so beware. Therefore you should make sure to delete
-    ///       the buffer once parsing is complete.
-    ///
-    /// @param {Id.Buffer} buff
-    ///   The ID of the GML buffer to use.
-    ///
-    /// @param {Real} [offset]
-    ///   The offset in the buffer to start parsing from. Defaults to 0.
-    ///
-    /// @param {Real} [size]
-    ///   The length of the buffer input. Any characters beyond this limit
-    ///   will be treated as the end of the file. Defaults to `infinity`.
-    ///
-    /// @return {Struct.Future}
-    static parseAsync = function (buff, offset=undefined, size=undefined) {
-        __catspeak_error_unimplemented("async-parsing");
-    };
-
-    /// Compiles a syntax graph into a GML function. See the [parse] function
-    /// for how to generate a syntax graph from a Catspeak script.
-    ///
-    /// @param {Struct} asg
-    ///   The syntax graph to convert into a GML function.
-    ///
-    /// @return {Function}
-    static compileGML = function (asg) {
-        // CatspeakGMLCompiler() will do argument validation
-        var compiler = new CatspeakGMLCompiler(asg, interface);
-        var result;
-        do {
-            result = compiler.update();
-        } until (result != undefined);
-        return result;
     };
 }
 

--- a/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
+++ b/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
@@ -65,6 +65,15 @@ test_add(function () : Test("engine-global-shared") constructor {
     assertEq(1, fB());
 });
 
+test_add(function () : Test("engine-global-shared-2") constructor {
+    var engine = new CatspeakEnvironment();
+    engine.enableSharedGlobal(true);
+    var fA = engine.compileGML(engine.parseString(@'globalvar = 1;'));
+    var fB = engine.compileGML(engine.parseString(@'globalvar'));
+    fA();
+    assertEq(1, fB());
+});
+
 test_add(function () : Test("engine-delete-keyword") constructor {
     var engine = new CatspeakEnvironment();
     engine.removeKeyword("fun");


### PR DESCRIPTION
Implemented a method `enableSharedGlobal` on `CatspeakEnvironment` which allows any compiled Catspeak programs to share the same global scope. Useful for developer consoles where variables persist between commands.