### PR TITLE
Dev 3.0.0 - `addGMAsset`, `addGMLFunction`, and `addGMLFunctionBySubstring`

### DIFF
--- a/src-lts/scripts/scr_catspeak_environment/scr_catspeak_environment.gml
+++ b/src-lts/scripts/scr_catspeak_environment/scr_catspeak_environment.gml
@@ -383,6 +383,40 @@ function CatspeakEnvironment() constructor {
             interface_[$ name] = func;
         }
     }
+    
+    /// Used to add a bunch of GML functions to this environment by substring matching. 
+    /// So "scribble" would add "scribble*", "scribble_*" and "scribble_scribble_*" but not "__scribble*"
+    ///
+    /// @param {String} substr
+    ///   The function that you want to add to Catspeak as is.
+    ///
+    /// @param {Function} ...
+    ///   Additional arguments in the same function format.
+    static addGMLFunctionBySubstring = function () {
+        interface ??= { };
+        var interface_ = interface;    
+        for(var i = 0; i < argument_count; i++) {
+            var subStr = argument[i];
+            if (CATSPEAK_DEBUG_MODE) {
+                __catspeak_check_arg("substr", subStr, is_string);
+            }
+            var strLen = string_length(subStr);
+            // Asset scanning for functions can be a lil weird.
+            // In my experience, I've came across a few variations.
+            // Their positions aren't always 100% known, except for anon (which is always at the front)
+            var j = 100001;
+            while(script_exists(j)) {
+                var name = script_get_name(j);
+                if ((string_copy(name, 1, 4) != "anon") && (string_count("gml_GlobalScript", name) == 0) && (string_count("__struct__", name) == 0)) {
+                    if (string_copy(name, 1, strLen) == subStr) {
+                        var func = method(undefined, j);
+                        interface_[$ name] = func; 
+                    }
+                }
+                ++j;
+            }
+        }
+    }
 }
 
 /// A usability function for converting special GML constants, such as

--- a/src-lts/scripts/scr_catspeak_environment/scr_catspeak_environment.gml
+++ b/src-lts/scripts/scr_catspeak_environment/scr_catspeak_environment.gml
@@ -326,6 +326,63 @@ function CatspeakEnvironment() constructor {
             }
         }
     };
+
+    /// Used to add a GM Asset as a constant value to this enviornment.
+    ///
+    /// NOTE: Although you can use this to add functions, it's recommended
+    ///       to use [addFunction] for that purpose instead. 
+    ///       And to remove the GM asset, you'll need to use .removeConstant
+    ///
+    /// @param {String} name
+    ///   The name of the GM asset that you wish to expose to Catspeak.
+    ///
+    /// @param {String} ...
+    ///   Additional GM assets to add.
+    static addGMAsset = function () {
+        interface ??= { };
+        var interface_ = interface;
+
+        for (var i = 0; i < argument_count; i++) {
+            var name = argument[i];
+            var value = asset_get_index(argument[i]);
+            if (CATSPEAK_DEBUG_MODE) {
+                __catspeak_check_arg("name", name, is_string);
+            }
+            
+            // Validate that it's an actual GM Asset
+            if (value == -1) {
+                __catspeak_error("Invalid GMAsset! Got " + string(value) + " from " + string(name));	
+            }
+            
+            interface_[$ name] = value;
+        }
+    }
+
+    /// Used to add a new GML function to this environment as is. 
+    ///
+    /// @param {Function} function
+    ///   The function that you want to add to Catspeak as is.
+    ///
+    /// @param {Function} ...
+    ///   Additional arguments in the same function format.
+    static addGMLFunction = function () {
+        interface ??= { };
+        var interface_ = interface;
+        for(var i = 0; i < argument_count; i++) {
+            // Seems silly to check that a GML function is a method
+            // even though we are going to be adding it in as a method anyway.
+            // But we don't want to mix in actual methods in here before proceeding.
+            if (CATSPEAK_DEBUG_MODE) {
+                if (is_method(argument[i])) {
+                    __catspeak_error("Cannot add method as a GML function!");
+                }
+            }
+            
+            var name = script_get_name(argument[i]);
+            var func = method(undefined, argument[i]);
+            interface_[$ name] = func;
+        }
+    }
 }
 
 /// A usability function for converting special GML constants, such as

--- a/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
+++ b/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
@@ -279,3 +279,15 @@ test_add(function () : Test("engine-gml-function") constructor {
     var result = func();
     assertEq(result, true);
 }); 
+
+test_add(function () : Test("engine-gml-function-by-substring") constructor {
+    var engine = new CatspeakEnvironment();
+    engine.addGMLFunctionBySubstring("array");
+    var asg = engine.parseString(@'
+        let array = [2, 2, 4];
+        return array_sum(array);
+    ');
+    var func = engine.compileGML(asg);
+    var result = func();
+    assertEq(result, 8);
+}); 

--- a/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
+++ b/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
@@ -256,3 +256,26 @@ test_add(function () : Test("engine-pipe-right") constructor {
     '));
     assertEq("helloworld", f());
 });
+
+test_add(function () : Test("engine-gm-asset") constructor {
+    var engine = new CatspeakEnvironment();
+    engine.addFunction("font_exists", font_exists);
+    engine.addGMAsset("fnt_testing");
+    var asg = engine.parseString(@'
+        return font_exists(fnt_testing);
+    ');
+    var func = engine.compileGML(asg);
+    var result = func();
+    assertEq(result, true);
+}); 
+
+test_add(function () : Test("engine-gml-function") constructor {
+    var engine = new CatspeakEnvironment();
+    engine.addGMLFunction(is_string);
+    var asg = engine.parseString(@'
+        return is_string("Hello World!");
+    ');
+    var func = engine.compileGML(asg);
+    var result = func();
+    assertEq(result, true);
+}); 

--- a/src-lts/scripts/scr_testing_example_functions/scr_testing_example_functions.gml
+++ b/src-lts/scripts/scr_testing_example_functions/scr_testing_example_functions.gml
@@ -1,0 +1,32 @@
+// Example functions for the test case "engine-gml-function-by-substring"
+
+// Everything that starts with "array" should be exposed in "engine-gml-function-by-substring".
+function array_sum(array) {
+    var len = array_length(array);
+    var sum = 0;
+    for(var i = 0; i < len; i++) {
+        sum += array[i];
+    }
+    return sum;
+}
+
+function array_min(array) {
+    return script_execute_ext(min, array);   
+}
+
+function array_max(array) {
+    return script_execute_ext(max, array);   
+}
+
+function array_mean(array) {
+    return script_execute_ext(mean, array);   
+}
+
+function array_median(array) {
+    return script_execute_ext(median, array);   
+}
+
+// This should never be added, since it doesn't contain "array" at the front.
+function struct_create() {
+    return {};   
+}

--- a/src-lts/scripts/scr_testing_example_functions/scr_testing_example_functions.yy
+++ b/src-lts/scripts/scr_testing_example_functions/scr_testing_example_functions.yy
@@ -1,0 +1,11 @@
+{
+  "resourceType": "GMScript",
+  "resourceVersion": "1.0",
+  "name": "scr_testing_example_functions",
+  "isDnD": false,
+  "isCompatibility": false,
+  "parent": {
+    "name": "examples",
+    "path": "folders/Testing/demo/examples.yy",
+  },
+}


### PR DESCRIPTION
Took me a bit to write these up. From previous discussions on Discord, I've came up with these three small but very helpful functions.

```
env.addGMAsset("spr_player", "fnt_text", "obj_player", "obj_wall") 
env.addGMLFunction(lengthdir_x, lengthdir_y) 
env.addGMLFunctionBySubstring("array")
```

`env.addGMAsset()` is similar to as `env.addConstant()` but includes extra checks to make sure that it's a valid asset index from a name.

`env.addGMLFunction()` is similar to `env.addFunction()`, except it adds in a function index as per the name and index. And prevents methods from being added in directly. This does include built in functions, such as `lengthdir_x`.

`env.addGMLFunctionBySubstring()` is similar to `env.addFunction()`, but scans all user function indexes for each substring that is passed (starting from 100001, meaning that built-in functions are ignored) and adds anything that matches the substring with the first part of the name. So `"scribble"` would add `"scribble"`, `"scribble_*` but not `"__scribble"` or `"scr_scribble"`. 

The name for `addGMLFunctionBySubstring` I'm not really settled on entirely, but I am open to suggestions on what could be better named. (alynne suggested `PartialName` in place of `Substring`). 

All of these do include test cases. And for `.addGMLFunctionBySubstring()`, I've included `scr_testing_example_functions` for the demonstration of what it does/doesn't add in.