### PR TITLE
Fix 3.0.0 - Fixed issue with instances not being recognized as "structs"

### DIFF
--- a/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
+++ b/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
@@ -1088,7 +1088,7 @@ function __catspeak_expr_index_get__() {
     var key_ = key();
     if (is_array(collection_)) {
         return collection_[key_];
-    } else if (is_struct(collection_)) || (__catspeak_is_withable(collection_)) {
+    } else if (__catspeak_is_withable(collection_)) {
         return collection_[$ key_];
     } else {
         __catspeak_error_got(dbgError, collection_);
@@ -1103,7 +1103,7 @@ function __catspeak_expr_index_set__() {
     var value_ = value();
     if (is_array(collection_)) {
         collection_[@ key_] = value_;
-    } else if (is_struct(collection_)) || (__catspeak_is_withable(collection_)) {
+    } else if (__catspeak_is_withable(collection_)) {
         collection_[$ key_] = value_;
     } else {
         __catspeak_error_got(dbgError, collection_);
@@ -1118,7 +1118,7 @@ function __catspeak_expr_index_set_mult__() {
     var value_ = value();
     if (is_array(collection_)) {
         collection_[@ key_] *= value_;
-    } else if (is_struct(collection_)) || (__catspeak_is_withable(collection_)) {
+    } else if (__catspeak_is_withable(collection_)) {
         collection_[$ key_] *= value_;
     } else {
         __catspeak_error_got(dbgError, collection_);
@@ -1133,7 +1133,7 @@ function __catspeak_expr_index_set_div__() {
     var value_ = value();
     if (is_array(collection_)) {
         collection_[@ key_] /= value_;
-    } else if (is_struct(collection_)) || (__catspeak_is_withable(collection_)) {
+    } else if (__catspeak_is_withable(collection_)) {
         collection_[$ key_] /= value_;
     } else {
         __catspeak_error_got(dbgError, collection_);
@@ -1148,7 +1148,7 @@ function __catspeak_expr_index_set_sub__() {
     var value_ = value();
     if (is_array(collection_)) {
         collection_[@ key_] -= value_;
-    } else if (is_struct(collection_)) || (__catspeak_is_withable(collection_)) {
+    } else if (__catspeak_is_withable(collection_)) {
         collection_[$ key_] -= value_;
     } else {
         __catspeak_error_got(dbgError, collection_);
@@ -1163,7 +1163,7 @@ function __catspeak_expr_index_set_plus__() {
     var value_ = value();
     if (is_array(collection_)) {
         collection_[@ key_] += value_;
-    } else if (is_struct(collection_)) || (__catspeak_is_withable(collection_)) {
+    } else if (__catspeak_is_withable(collection_)) {
         collection_[$ key_] += value_;
     } else {
         __catspeak_error_got(dbgError, collection_);

--- a/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
+++ b/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
@@ -1088,7 +1088,7 @@ function __catspeak_expr_index_get__() {
     var key_ = key();
     if (is_array(collection_)) {
         return collection_[key_];
-    } else if (is_struct(collection_)) {
+    } else if (is_struct(collection_)) || (instance_exists(collection_)) {
         return collection_[$ key_];
     } else {
         __catspeak_error_got(dbgError, collection_);
@@ -1103,7 +1103,7 @@ function __catspeak_expr_index_set__() {
     var value_ = value();
     if (is_array(collection_)) {
         collection_[@ key_] = value_;
-    } else if (is_struct(collection_)) {
+    } else if (is_struct(collection_)) || (instance_exists(collection_)) {
         collection_[$ key_] = value_;
     } else {
         __catspeak_error_got(dbgError, collection_);
@@ -1118,7 +1118,7 @@ function __catspeak_expr_index_set_mult__() {
     var value_ = value();
     if (is_array(collection_)) {
         collection_[@ key_] *= value_;
-    } else if (is_struct(collection_)) {
+    } else if (is_struct(collection_)) || (instance_exists(collection_)) {
         collection_[$ key_] *= value_;
     } else {
         __catspeak_error_got(dbgError, collection_);
@@ -1133,7 +1133,7 @@ function __catspeak_expr_index_set_div__() {
     var value_ = value();
     if (is_array(collection_)) {
         collection_[@ key_] /= value_;
-    } else if (is_struct(collection_)) {
+    } else if (is_struct(collection_)) || (instance_exists(collection_)) {
         collection_[$ key_] /= value_;
     } else {
         __catspeak_error_got(dbgError, collection_);
@@ -1148,7 +1148,7 @@ function __catspeak_expr_index_set_sub__() {
     var value_ = value();
     if (is_array(collection_)) {
         collection_[@ key_] -= value_;
-    } else if (is_struct(collection_)) {
+    } else if (is_struct(collection_)) || (instance_exists(collection_)) {
         collection_[$ key_] -= value_;
     } else {
         __catspeak_error_got(dbgError, collection_);
@@ -1163,7 +1163,7 @@ function __catspeak_expr_index_set_plus__() {
     var value_ = value();
     if (is_array(collection_)) {
         collection_[@ key_] += value_;
-    } else if (is_struct(collection_)) {
+    } else if (is_struct(collection_)) || (instance_exists(collection_)) {
         collection_[$ key_] += value_;
     } else {
         __catspeak_error_got(dbgError, collection_);

--- a/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
+++ b/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
@@ -1088,7 +1088,7 @@ function __catspeak_expr_index_get__() {
     var key_ = key();
     if (is_array(collection_)) {
         return collection_[key_];
-    } else if (is_struct(collection_)) || (instance_exists(collection_)) {
+    } else if (is_struct(collection_)) || (__catspeak_is_withable(collection_)) {
         return collection_[$ key_];
     } else {
         __catspeak_error_got(dbgError, collection_);
@@ -1103,7 +1103,7 @@ function __catspeak_expr_index_set__() {
     var value_ = value();
     if (is_array(collection_)) {
         collection_[@ key_] = value_;
-    } else if (is_struct(collection_)) || (instance_exists(collection_)) {
+    } else if (is_struct(collection_)) || (__catspeak_is_withable(collection_)) {
         collection_[$ key_] = value_;
     } else {
         __catspeak_error_got(dbgError, collection_);
@@ -1118,7 +1118,7 @@ function __catspeak_expr_index_set_mult__() {
     var value_ = value();
     if (is_array(collection_)) {
         collection_[@ key_] *= value_;
-    } else if (is_struct(collection_)) || (instance_exists(collection_)) {
+    } else if (is_struct(collection_)) || (__catspeak_is_withable(collection_)) {
         collection_[$ key_] *= value_;
     } else {
         __catspeak_error_got(dbgError, collection_);
@@ -1133,7 +1133,7 @@ function __catspeak_expr_index_set_div__() {
     var value_ = value();
     if (is_array(collection_)) {
         collection_[@ key_] /= value_;
-    } else if (is_struct(collection_)) || (instance_exists(collection_)) {
+    } else if (is_struct(collection_)) || (__catspeak_is_withable(collection_)) {
         collection_[$ key_] /= value_;
     } else {
         __catspeak_error_got(dbgError, collection_);
@@ -1148,7 +1148,7 @@ function __catspeak_expr_index_set_sub__() {
     var value_ = value();
     if (is_array(collection_)) {
         collection_[@ key_] -= value_;
-    } else if (is_struct(collection_)) || (instance_exists(collection_)) {
+    } else if (is_struct(collection_)) || (__catspeak_is_withable(collection_)) {
         collection_[$ key_] -= value_;
     } else {
         __catspeak_error_got(dbgError, collection_);
@@ -1163,7 +1163,7 @@ function __catspeak_expr_index_set_plus__() {
     var value_ = value();
     if (is_array(collection_)) {
         collection_[@ key_] += value_;
-    } else if (is_struct(collection_)) || (instance_exists(collection_)) {
+    } else if (is_struct(collection_)) || (__catspeak_is_withable(collection_)) {
         collection_[$ key_] += value_;
     } else {
         __catspeak_error_got(dbgError, collection_);


### PR DESCRIPTION
Seems like a sort of weird GM quirk territory.
But applying an instance via `.setSelf(instance_id)` and then trying to do this in catspeak, results in an unexpected error.
```
Catspeak v3.0.0: runtime error in a file at (line 12, column 25) -- variable 'self' is not indexable, got 'struct'
 at gml_Script___catspeak_error (line 25) -     show_error(msg, false);
 ```

Catspeak code:
```
self.number = 10;
self.number += 10;
self.number /= 2;
self.number *= 4;
show_debug_message(self.number);
```
Narrowing it down has lead to me finding out that despite `.setSelf(instance_id)` passing in `self`, it treats it as an instance moreso. And therefore fails the `is_struct` check.
The I've applied here allows all of this to work for instances.