### PR TITLE
Dev 3.0.0 - Implement `match` expression

### DIFF
--- a/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
+++ b/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
@@ -657,32 +657,32 @@ function CatspeakGMLCompiler(asg, interface=undefined) constructor {
             body : __compileTerm(ctx, term.body),
         }, __catspeak_expr_while__);
     };
-	
-	/// @ignore
+
+    /// @ignore
     ///
     /// @param {Struct} ctx
     /// @param {Struct} term
     /// @return {Function}
-	static __compileMatch = function(ctx, term) {
-		var i = 0;
-		var n = array_length(term.arms);
-		
-		repeat n {
-			var pair = term.arms[i];
-			
-			term.arms[i] = {
-				condition: pair[0] == undefined ? undefined : __compileTerm(ctx, pair[0]),
-				result: __compileTerm(ctx, pair[1]),
-			};
+    static __compileMatch = function(ctx, term) {
+        var i = 0;
+        var n = array_length(term.arms);
+        
+        repeat n {
+            var pair = term.arms[i];
+            
+            term.arms[i] = {
+                condition: pair[0] == undefined ? undefined : __compileTerm(ctx, pair[0]),
+                result: __compileTerm(ctx, pair[1]),
+            };
 
-			i++;
-		}
-		
-		return method({
-			value: __compileTerm(ctx, term.value),
-			arms: term.arms,
-		}, __catspeak_expr_match__);
-	};
+            i++;
+        }
+        
+        return method({
+            value: __compileTerm(ctx, term.value),
+            arms: term.arms,
+        }, __catspeak_expr_match__);
+    };
 
     /// @ignore
     ///
@@ -1133,7 +1133,7 @@ function CatspeakGMLCompiler(asg, interface=undefined) constructor {
         db[@ CatspeakTerm.BLOCK] = __compileBlock;
         db[@ CatspeakTerm.IF] = __compileIf;
         db[@ CatspeakTerm.WHILE] = __compileWhile;
-		db[@ CatspeakTerm.MATCH] = __compileMatch;
+        db[@ CatspeakTerm.MATCH] = __compileMatch;
         db[@ CatspeakTerm.USE] = __compileUse;
         db[@ CatspeakTerm.RETURN] = __compileReturn;
         db[@ CatspeakTerm.BREAK] = __compileBreak;
@@ -1266,11 +1266,11 @@ function __catspeak_expr_value__() {
 /// @ignore
 /// @return {Any}
 function __catspeak_expr_array__() {
-	//return array_map(values, function(f) { return f() });
-	var i = 0;
+    //return array_map(values, function(f) { return f() });
+    var i = 0;
     var values_ = values;
     var n_ = n;
-	var arr = array_create(n_);
+    var arr = array_create(n_);
     repeat (n_) {
         // not sure if this is even fast
         // but people will cry if I don't do it
@@ -1397,22 +1397,22 @@ function __catspeak_expr_while__() {
 /// @ignore
 ///@return {Any}
 function __catspeak_expr_match__() {
-	var value_ = value();
-	
-	var i = 0;
-	var len = array_length(arms);
-	
-	repeat len {
-		var arm = arms[i];
-		
-		if arm.condition == undefined || value_ == arm.condition() {
-			return arm.result();
-		}
-		
-		i++;
-	}
-	
-	return undefined;
+    var value_ = value();
+    
+    var i = 0;
+    var len = array_length(arms);
+    
+    repeat len {
+        var arm = arms[i];
+        
+        if arm.condition == undefined || value_ == arm.condition() {
+            return arm.result();
+        }
+        
+        i++;
+    }
+    
+    return undefined;
 }
 
 /// @ignore

--- a/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
+++ b/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
@@ -657,6 +657,32 @@ function CatspeakGMLCompiler(asg, interface=undefined) constructor {
             body : __compileTerm(ctx, term.body),
         }, __catspeak_expr_while__);
     };
+	
+	/// @ignore
+    ///
+    /// @param {Struct} ctx
+    /// @param {Struct} term
+    /// @return {Function}
+	static __compileMatch = function(ctx, term) {
+		var i = 0;
+		var n = array_length(term.arms);
+		
+		repeat n {
+			var pair = term.arms[i];
+			
+			term.arms[i] = {
+				condition: pair[0] == undefined ? undefined : __compileTerm(ctx, pair[0]),
+				result: __compileTerm(ctx, pair[1]),
+			};
+
+			i++;
+		}
+		
+		return method({
+			value: __compileTerm(ctx, term.value),
+			arms: term.arms,
+		}, __catspeak_expr_match__);
+	};
 
     /// @ignore
     ///
@@ -1107,6 +1133,7 @@ function CatspeakGMLCompiler(asg, interface=undefined) constructor {
         db[@ CatspeakTerm.BLOCK] = __compileBlock;
         db[@ CatspeakTerm.IF] = __compileIf;
         db[@ CatspeakTerm.WHILE] = __compileWhile;
+		db[@ CatspeakTerm.MATCH] = __compileMatch;
         db[@ CatspeakTerm.USE] = __compileUse;
         db[@ CatspeakTerm.RETURN] = __compileReturn;
         db[@ CatspeakTerm.BREAK] = __compileBreak;
@@ -1365,6 +1392,27 @@ function __catspeak_expr_while__() {
             }
         }
     }
+}
+
+/// @ignore
+///@return {Any}
+function __catspeak_expr_match__() {
+	var value_ = value();
+	
+	var i = 0;
+	var len = array_length(arms);
+	
+	repeat len {
+		var arm = arms[i];
+		
+		if arm.condition == undefined || value_ == arm.condition() {
+			return arm.result();
+		}
+		
+		i++;
+	}
+	
+	return undefined;
 }
 
 /// @ignore

--- a/src-lts/scripts/scr_catspeak_ir/scr_catspeak_ir.gml
+++ b/src-lts/scripts/scr_catspeak_ir/scr_catspeak_ir.gml
@@ -151,23 +151,23 @@ function CatspeakIRBuilder() constructor {
             });
         }
     };
-	
-	/// Emits the instruction for a match expression.
-	///
-	/// @param {Struct} value
-	///   The term to evaluate and compare against.
-	///
-	/// @param {Array} arms
-	///   A list of pairs where the first term is compared against `value` and the second term is returned if both match.
-	///
-	/// @param {Real} [location]
-	///   The source location of this match term.
-	static createMatch = function(value, arms, location = undefined) {
-		return __createTerm(CatspeakTerm.MATCH, location, {
-			value: value,
-			arms: arms,
-		});
-	}
+    
+    /// Emits the instruction for a match expression.
+    ///
+    /// @param {Struct} value
+    ///   The term to evaluate and compare against.
+    ///
+    /// @param {Array} arms
+    ///   A list of pairs where the first term is compared against `value` and the second term is returned if both match.
+    ///
+    /// @param {Real} [location]
+    ///   The source location of this match term.
+    static createMatch = function(value, arms, location = undefined) {
+        return __createTerm(CatspeakTerm.MATCH, location, {
+            value: value,
+            arms: arms,
+        });
+    }
 
     /// Emits the instruction for a short-circuiting logical AND expression.
     ///
@@ -876,7 +876,7 @@ enum CatspeakTerm {
     AND,
     OR,
     WHILE,
-	MATCH,
+    MATCH,
     USE,
     RETURN,
     BREAK,

--- a/src-lts/scripts/scr_catspeak_ir/scr_catspeak_ir.gml
+++ b/src-lts/scripts/scr_catspeak_ir/scr_catspeak_ir.gml
@@ -151,6 +151,23 @@ function CatspeakIRBuilder() constructor {
             });
         }
     };
+	
+	/// Emits the instruction for a match expression.
+	///
+	/// @param {Struct} value
+	///   The term to evaluate and compare against.
+	///
+	/// @param {Array} arms
+	///   A list of pairs where the first term is compared against `value` and the second term is returned if both match.
+	///
+	/// @param {Real} [location]
+	///   The source location of this match term.
+	static createMatch = function(value, arms, location = undefined) {
+		return __createTerm(CatspeakTerm.MATCH, location, {
+			value: value,
+			arms: arms,
+		});
+	}
 
     /// Emits the instruction for a short-circuiting logical AND expression.
     ///
@@ -859,6 +876,7 @@ enum CatspeakTerm {
     AND,
     OR,
     WHILE,
+	MATCH,
     USE,
     RETURN,
     BREAK,

--- a/src-lts/scripts/scr_catspeak_lexer/scr_catspeak_lexer.gml
+++ b/src-lts/scripts/scr_catspeak_lexer/scr_catspeak_lexer.gml
@@ -34,6 +34,8 @@ enum CatspeakToken {
     COMMA,
     /// The `.` operator.
     DOT,
+	/// The `=>` operator.
+	ARROW,
     __OP_ASSIGN_BEGIN__,
     /// The `=` operator.
     ASSIGN,
@@ -104,6 +106,8 @@ enum CatspeakToken {
     FOR,
     /// The `loop` keyword.
     LOOP,
+	/// The `match` keyword.
+	MATCH,
     /// The `use` keyword.
     USE,
     /// The `let` keyword.
@@ -907,6 +911,7 @@ function __catspeak_keywords_create() {
     keywords[$ ":"] = CatspeakToken.COLON;
     keywords[$ ","] = CatspeakToken.COMMA;
     keywords[$ "."] = CatspeakToken.DOT;
+	keywords[$ "=>"] = CatspeakToken.ARROW;
     keywords[$ "="] = CatspeakToken.ASSIGN;
     keywords[$ "*="] = CatspeakToken.ASSIGN_MULTIPLY;
     keywords[$ "/="] = CatspeakToken.ASSIGN_DIVIDE;
@@ -941,6 +946,7 @@ function __catspeak_keywords_create() {
     keywords[$ "while"] = CatspeakToken.WHILE;
     keywords[$ "for"] = CatspeakToken.FOR;
     keywords[$ "loop"] = CatspeakToken.LOOP;
+	keywords[$ "match"] = CatspeakToken.MATCH;
     keywords[$ "use"] = CatspeakToken.USE;
     keywords[$ "let"] = CatspeakToken.LET;
     keywords[$ "fun"] = CatspeakToken.FUN;

--- a/src-lts/scripts/scr_catspeak_lexer/scr_catspeak_lexer.gml
+++ b/src-lts/scripts/scr_catspeak_lexer/scr_catspeak_lexer.gml
@@ -34,8 +34,8 @@ enum CatspeakToken {
     COMMA,
     /// The `.` operator.
     DOT,
-	/// The `=>` operator.
-	ARROW,
+    /// The `=>` operator.
+    ARROW,
     __OP_ASSIGN_BEGIN__,
     /// The `=` operator.
     ASSIGN,
@@ -106,8 +106,8 @@ enum CatspeakToken {
     FOR,
     /// The `loop` keyword.
     LOOP,
-	/// The `match` keyword.
-	MATCH,
+    /// The `match` keyword.
+    MATCH,
     /// The `use` keyword.
     USE,
     /// The `let` keyword.
@@ -911,7 +911,7 @@ function __catspeak_keywords_create() {
     keywords[$ ":"] = CatspeakToken.COLON;
     keywords[$ ","] = CatspeakToken.COMMA;
     keywords[$ "."] = CatspeakToken.DOT;
-	keywords[$ "=>"] = CatspeakToken.ARROW;
+    keywords[$ "=>"] = CatspeakToken.ARROW;
     keywords[$ "="] = CatspeakToken.ASSIGN;
     keywords[$ "*="] = CatspeakToken.ASSIGN_MULTIPLY;
     keywords[$ "/="] = CatspeakToken.ASSIGN_DIVIDE;
@@ -946,7 +946,7 @@ function __catspeak_keywords_create() {
     keywords[$ "while"] = CatspeakToken.WHILE;
     keywords[$ "for"] = CatspeakToken.FOR;
     keywords[$ "loop"] = CatspeakToken.LOOP;
-	keywords[$ "match"] = CatspeakToken.MATCH;
+    keywords[$ "match"] = CatspeakToken.MATCH;
     keywords[$ "use"] = CatspeakToken.USE;
     keywords[$ "let"] = CatspeakToken.LET;
     keywords[$ "fun"] = CatspeakToken.FUN;

--- a/src-lts/scripts/scr_catspeak_parser/scr_catspeak_parser.gml
+++ b/src-lts/scripts/scr_catspeak_parser/scr_catspeak_parser.gml
@@ -167,11 +167,11 @@ function CatspeakParser(lexer, builder) constructor {
             var body = asg.popBlock();
             return asg.createWhile(condition, body, lexer.getLocation());
         } else if (peeked == CatspeakToken.MATCH) {
-			lexer.next();
-			var value = __parseExpression();
-			var conditions = __parseMatchArms();
-			return asg.createMatch(value, conditions, lexer.getLocation());
-		} else if (peeked == CatspeakToken.USE) {
+            lexer.next();
+            var value = __parseExpression();
+            var conditions = __parseMatchArms();
+            return asg.createMatch(value, conditions, lexer.getLocation());
+        } else if (peeked == CatspeakToken.USE) {
             lexer.next();
             var condition = __parseCondition();
             asg.pushBlock();
@@ -455,46 +455,46 @@ function CatspeakParser(lexer, builder) constructor {
             return __parseIndex();
         }
     };
-	
-	/// @ignore
-	///
-	/// @return {Array}
-	static __parseMatchArms = function () {
-		if (lexer.next() != CatspeakToken.BRACE_LEFT) {
+    
+    /// @ignore
+    ///
+    /// @return {Array}
+    static __parseMatchArms = function () {
+        if (lexer.next() != CatspeakToken.BRACE_LEFT) {
             __ex("expected opening '{' before 'match' arms");
         }
-		
-		var conditions = [];
-		
+        
+        var conditions = [];
+        
         while (__isNot(CatspeakToken.BRACE_RIGHT)) {
-			var value;
-			
-			if (lexer.peek() == CatspeakToken.ELSE) {
-				lexer.next();
-				value = undefined;
-			} else {
-				value = __parseExpression();
-			}
-				   
-			if (lexer.next() != CatspeakToken.ARROW) {
-				__ex("expected match condition to be followed with an arrow '=>'");
-			}
-		   
-			var result = __parseExpression();
-		   
-			if (lexer.next() != CatspeakToken.COMMA) {
-				__ex("expected match arm to be termined with a comma ','");
-			}
-		   
-			array_push(conditions, [value, result]);
+            var value;
+            
+            if (lexer.peek() == CatspeakToken.ELSE) {
+                lexer.next();
+                value = undefined;
+            } else {
+                value = __parseExpression();
+            }
+                   
+            if (lexer.next() != CatspeakToken.ARROW) {
+                __ex("expected match condition to be followed with an arrow '=>'");
+            }
+           
+            var result = __parseExpression();
+           
+            if (lexer.next() != CatspeakToken.COMMA) {
+                __ex("expected match arm to be termined with a comma ','");
+            }
+           
+            array_push(conditions, [value, result]);
         }
-		
+        
         if (lexer.next() != CatspeakToken.BRACE_RIGHT) {
             __ex("expected closing '}' after 'match' arms");
         }
-		
-		return conditions;
-	}
+        
+        return conditions;
+    }
 
     /// @ignore
     ///

--- a/src-lts/scripts/scr_catspeak_parser/scr_catspeak_parser.gml
+++ b/src-lts/scripts/scr_catspeak_parser/scr_catspeak_parser.gml
@@ -166,7 +166,12 @@ function CatspeakParser(lexer, builder) constructor {
             __parseStatements("while");
             var body = asg.popBlock();
             return asg.createWhile(condition, body, lexer.getLocation());
-        } else if (peeked == CatspeakToken.USE) {
+        } else if (peeked == CatspeakToken.MATCH) {
+			lexer.next();
+			var value = __parseExpression();
+			var conditions = __parseMatchArms();
+			return asg.createMatch(value, conditions, lexer.getLocation());
+		} else if (peeked == CatspeakToken.USE) {
             lexer.next();
             var condition = __parseCondition();
             asg.pushBlock();
@@ -450,6 +455,46 @@ function CatspeakParser(lexer, builder) constructor {
             return __parseIndex();
         }
     };
+	
+	/// @ignore
+	///
+	/// @return {Array}
+	static __parseMatchArms = function () {
+		if (lexer.next() != CatspeakToken.BRACE_LEFT) {
+            __ex("expected opening '{' before 'match' arms");
+        }
+		
+		var conditions = [];
+		
+        while (__isNot(CatspeakToken.BRACE_RIGHT)) {
+			var value;
+			
+			if (lexer.peek() == CatspeakToken.ELSE) {
+				lexer.next();
+				value = undefined;
+			} else {
+				value = __parseExpression();
+			}
+				   
+			if (lexer.next() != CatspeakToken.ARROW) {
+				__ex("expected match condition to be followed with an arrow '=>'");
+			}
+		   
+			var result = __parseExpression();
+		   
+			if (lexer.next() != CatspeakToken.COMMA) {
+				__ex("expected match arm to be termined with a comma ','");
+			}
+		   
+			array_push(conditions, [value, result]);
+        }
+		
+        if (lexer.next() != CatspeakToken.BRACE_RIGHT) {
+            __ex("expected closing '}' after 'match' arms");
+        }
+		
+		return conditions;
+	}
 
     /// @ignore
     ///

--- a/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
+++ b/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
@@ -443,16 +443,16 @@ test_add_force(function () : Test(
 });
 
 test_add(function() : Test("match-1") constructor {
-	var engine = new CatspeakEnvironment();
+    var engine = new CatspeakEnvironment();
     var asg = engine.parseString(@'
         let a = 2
-		
-		match a {
-			1 => 69,
-			2 => 42,
-			3 => 3.14,
-			else => 0,
-		}
+        
+        match a {
+            1 => 69,
+            2 => 42,
+            3 => 3.14,
+            else => 0,
+        }
     ');
     var _func = engine.compileGML(asg);
     var result = _func();
@@ -460,16 +460,16 @@ test_add(function() : Test("match-1") constructor {
 });
 
 test_add(function() : Test("match-2") constructor {
-	var engine = new CatspeakEnvironment();
+    var engine = new CatspeakEnvironment();
     var asg = engine.parseString(@'
         let a = 2
-		
-		match a {
-			else => 0,
-			1 => 69,
-			2 => 42,
-			3 => 3.14,
-		}
+        
+        match a {
+            else => 0,
+            1 => 69,
+            2 => 42,
+            3 => 3.14,
+        }
     ');
     var _func = engine.compileGML(asg);
     var result = _func();
@@ -477,15 +477,15 @@ test_add(function() : Test("match-2") constructor {
 });
 
 test_add(function() : Test("match-3") constructor {
-	var engine = new CatspeakEnvironment();
+    var engine = new CatspeakEnvironment();
     var asg = engine.parseString(@'
         let a = 4
-		
-		match a {
-			1 => 69,
-			2 => 42,
-			3 => 3.14,
-		}
+        
+        match a {
+            1 => 69,
+            2 => 42,
+            3 => 3.14,
+        }
     ');
     var _func = engine.compileGML(asg);
     var result = _func();
@@ -493,10 +493,10 @@ test_add(function() : Test("match-3") constructor {
 });
 
 test_add(function() : Test("match-4") constructor {
-	var engine = new CatspeakEnvironment();
+    var engine = new CatspeakEnvironment();
     var asg = engine.parseString(@'
         let a = 0
-		match a {}
+        match a {}
     ');
     var _func = engine.compileGML(asg);
     var result = _func();
@@ -504,21 +504,21 @@ test_add(function() : Test("match-4") constructor {
 });
 
 test_add(function() : Test("match-5") constructor {
-	var engine = new CatspeakEnvironment();
+    var engine = new CatspeakEnvironment();
     var asg = engine.parseString(@'
         counter = 2;
-		
-		increment = fun {
-			counter += 1
-			counter
-		}
-		
-		match increment() {
-			1 => 0,
-			2 => 0,
-			3 => 1,
-			else => 2,
-		}
+        
+        increment = fun {
+            counter += 1
+            counter
+        }
+        
+        match increment() {
+            1 => 0,
+            2 => 0,
+            3 => 1,
+            else => 2,
+        }
     ');
     var _func = engine.compileGML(asg);
     var result = _func();

--- a/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
+++ b/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
@@ -441,3 +441,86 @@ test_add_force(function () : Test(
     var result = _func();
     assertEq(true, result);
 });
+
+test_add(function() : Test("match-1") constructor {
+	var engine = new CatspeakEnvironment();
+    var asg = engine.parseString(@'
+        let a = 2
+		
+		match a {
+			1 => 69,
+			2 => 42,
+			3 => 3.14,
+			else => 0,
+		}
+    ');
+    var _func = engine.compileGML(asg);
+    var result = _func();
+    assertEq(42, result);
+});
+
+test_add(function() : Test("match-2") constructor {
+	var engine = new CatspeakEnvironment();
+    var asg = engine.parseString(@'
+        let a = 2
+		
+		match a {
+			else => 0,
+			1 => 69,
+			2 => 42,
+			3 => 3.14,
+		}
+    ');
+    var _func = engine.compileGML(asg);
+    var result = _func();
+    assertEq(0, result);
+});
+
+test_add(function() : Test("match-3") constructor {
+	var engine = new CatspeakEnvironment();
+    var asg = engine.parseString(@'
+        let a = 4
+		
+		match a {
+			1 => 69,
+			2 => 42,
+			3 => 3.14,
+		}
+    ');
+    var _func = engine.compileGML(asg);
+    var result = _func();
+    assertEq(undefined, result);
+});
+
+test_add(function() : Test("match-4") constructor {
+	var engine = new CatspeakEnvironment();
+    var asg = engine.parseString(@'
+        let a = 0
+		match a {}
+    ');
+    var _func = engine.compileGML(asg);
+    var result = _func();
+    assertEq(undefined, result);
+});
+
+test_add(function() : Test("match-5") constructor {
+	var engine = new CatspeakEnvironment();
+    var asg = engine.parseString(@'
+        counter = 2;
+		
+		increment = fun {
+			counter += 1
+			counter
+		}
+		
+		match increment() {
+			1 => 0,
+			2 => 0,
+			3 => 1,
+			else => 2,
+		}
+    ');
+    var _func = engine.compileGML(asg);
+    var result = _func();
+    assertEq(1, result);
+});

--- a/src-lts/scripts/scr_testing_lexer_keyword/scr_testing_lexer_keyword.gml
+++ b/src-lts/scripts/scr_testing_lexer_keyword/scr_testing_lexer_keyword.gml
@@ -25,6 +25,10 @@ test_add(function () : TestLexerToken("lexer-keyword-continue-line",
     CatspeakToken.WHITESPACE, "...", "..."
 ) constructor { });
 
+test_add(function () : TestLexerToken("lexer-keyword-arrow",
+    CatspeakToken.ARROW, "=>", "=>"
+) constructor { });
+
 test_add(function () : TestLexerToken("lexer-keyword-do",
     CatspeakToken.DO, "do", "do"
 ) constructor { });
@@ -47,6 +51,10 @@ test_add(function () : TestLexerToken("lexer-keyword-for",
 
 test_add(function () : TestLexerToken("lexer-keyword-loop",
     CatspeakToken.LOOP, "loop", "loop"
+) constructor { });
+
+test_add(function () : TestLexerToken("lexer-keyword-match",
+    CatspeakToken.MATCH, "match", "match"
 ) constructor { });
 
 test_add(function () : TestLexerToken("lexer-keyword-let",


### PR DESCRIPTION
The syntax is as follows:

```rust
match some_value {
    value1 => result1,
    value2 => result2,
    // ...
    else => otherwise,
}
```

This will evaluate expression `some_value` and compare the result against `value1`, `value2`, ... sequentially. If anything "matches" (is equal to `some_value`), the corresponding `result` is returned. Otherwise, whatever is in the optional `else` block is returned.

The `result`s and `value`s can be any expression including blocks. `value`s are evaluated lazily; if a match is found, no `value`s evaluate further.

`match` arms must currently end in a comma including the final arm. Rationale: it's the `rustfmt` default behavior, and this specific `match` syntax is inspired by Rust. Enforcing this rule also helps with parsing a little since no extra `peek`s are required. This can be changed if needed.

`match` returns `undefined` if the arms block is empty or if no conditions were met without an `else` block present.

The `=>` arrow token is now a thing too. It's only used for `match` as of now.

The current `match-{1..5}` unit tests don't cover everything, but that is totally fixable. Need a thorough review of what is done so far before adding more code.