### PR TITLE
Fix 3.0.1 - Fixed `catspeak_collect()` from crashing

### DIFF
--- a/src-lts/scripts/scr_catspeak_alloc/scr_catspeak_alloc.gml
+++ b/src-lts/scripts/scr_catspeak_alloc/scr_catspeak_alloc.gml
@@ -17,6 +17,8 @@ function catspeak_collect() {
         }
         weakRef.adapter.destroy(weakRef.ds);
         array_delete(pool, i, 1);
+		--i;
+		--poolSize;
     }
 }
 

--- a/src-lts/scripts/scr_catspeak_alloc/scr_catspeak_alloc.gml
+++ b/src-lts/scripts/scr_catspeak_alloc/scr_catspeak_alloc.gml
@@ -9,16 +9,14 @@ function catspeak_collect() {
         __catspeak_check_init();
     }
     var pool = global.__catspeakAllocPool;
-    var poolSize = array_length(pool);
-    for (var i = 0; i < poolSize; i += 1) {
+    var poolSize = array_length(pool)-1;
+    for (var i = poolSize; i >= 0; i -= 1) {
         var weakRef = pool[i];
         if (weak_ref_alive(weakRef)) {
             continue;
         }
         weakRef.adapter.destroy(weakRef.ds);
         array_delete(pool, i, 1);
-		--i;
-		--poolSize;
     }
 }
 


### PR DESCRIPTION
Without decrementing `i` or `poolSize`, eventually it attempts to collect from the pool at a position that's empty, resulting in a crash. This PR remedies this by decreasing both `i` and `poolSize` after deleting the dead weakref from the pool.