### PR TITLE
Fix 3.0.1 - `.parseString` memory leak and wrong environment

### DIFF
--- a/src-lts/scripts/scr_catspeak_environment/scr_catspeak_environment.gml
+++ b/src-lts/scripts/scr_catspeak_environment/scr_catspeak_environment.gml
@@ -172,7 +172,9 @@ function CatspeakEnvironment() constructor {
     /// @return {Struct.CatspeakLexer}
     static parseString = function (src) {
         var buff = __catspeak_create_buffer_from_string(src);
-        return Catspeak.parse(buff);
+        var result = parse(buff);
+        buffer_delete(buff);
+        return result;
     };
 
     /// Similar to `parse`, except it will pass the responsibility of


### PR DESCRIPTION
This in regards to #87. Calling `.parseString` uses the default Catspeak environment regardless, and also creates a memory leak on every call. 