### PR TITLE
Dev 3.1.0 - Added in clearing locals (by resizing them)

### DIFF
--- a/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
+++ b/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
@@ -1244,13 +1244,13 @@ function CatspeakGMLCompiler(ir, interface=undefined) constructor {
 /// @return {Any}
 function __catspeak_function__() {
     var isRecursing = callTime >= 0;
+    var localCount = array_length(locals);
     if (isRecursing) {
         // catch unbound recursion
         __catspeak_timeout_check(callTime);
         // store the previous local variable array
         // this will make function recursion quite expensive, but
         // hopefully that's uncommon enough for it to not matter
-        var localCount = array_length(locals);
         var oldLocals = array_create(localCount);
         array_copy(oldLocals, 0, locals, 0, localCount);
     } else {
@@ -1277,6 +1277,10 @@ function __catspeak_function__() {
         } else {
             // reset the timer
             callTime = -1;
+            // Clear locals
+            // Gone with array_resize, as it's faster to resize than to loop
+            array_resize(locals, 0);
+            array_resize(locals, localCount);
         }
     }
     return value;


### PR DESCRIPTION
I've implemented a way of clearing locals in my own game awhile ago. Given that any structs passed into a function linger around until the function is recalled, where at that point locals are refreshed.

This PR aims to improve that by clearing locals at the very end, resolving #91.
I've taken the `array_resize` approach, as loops aren't anywhere near as fast as `array_resize` the more locals there is needed to be cleared. Looping is only really beneficial if the local count is very low, and on YYC. I also have moved `localCount` to the top of the function, as `localCount` is also used for resetting the locals array back to it's original size.