### PR TITLE
Dev 3.1.0 - Method short circuiting to expr_call_0-3

### DIFF
--- a/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
+++ b/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
@@ -1830,7 +1830,12 @@ function __catspeak_expr_call_0__() {
         __catspeak_error_got(dbgError, callee_);
     }
     var shared_ = shared;
-    with (method_get_self(callee_) ?? (shared_.self_ ?? shared_.globals)) {
+	
+    if (method_get_self(callee_) != undefined) {
+        return callee_();
+    }
+	
+    with (shared_.self_ ?? shared_.globals) {
         var calleeIdx = method_get_index(callee_);
         return script_execute(calleeIdx);
     }
@@ -1846,7 +1851,12 @@ function __catspeak_expr_call_1__() {
     var values_ = args;
     var arg1 = values_[0]();
     var shared_ = shared;
-    with (method_get_self(callee_) ?? (shared_.self_ ?? shared_.globals)) {
+	
+    if (method_get_self(callee_) != undefined) {
+        return callee_(arg1);
+    }
+	
+    with (shared_.self_ ?? shared_.globals) {
         var calleeIdx = method_get_index(callee_);
         return script_execute(calleeIdx, arg1);
     }
@@ -1863,7 +1873,12 @@ function __catspeak_expr_call_2__() {
     var arg1 = values_[0]();
     var arg2 = values_[1]();
     var shared_ = shared;
-    with (method_get_self(callee_) ?? (shared_.self_ ?? shared_.globals)) {
+	
+    if (method_get_self(callee_) != undefined) {
+        return callee_(arg1, arg2);
+    }
+	
+    with (shared_.self_ ?? shared_.globals) {
         var calleeIdx = method_get_index(callee_);
         return script_execute(calleeIdx, arg1, arg2);
     }
@@ -1881,7 +1896,12 @@ function __catspeak_expr_call_3__() {
     var arg2 = values_[1]();
     var arg3 = values_[2]();
     var shared_ = shared;
-    with (method_get_self(callee_) ?? (shared_.self_ ?? shared_.globals)) {
+	
+    if (method_get_self(callee_) != undefined) {
+        return callee_(arg1, arg2, arg3);
+    }
+	
+    with (shared_.self_ ?? shared_.globals) {
         var calleeIdx = method_get_index(callee_);
         return script_execute(calleeIdx, arg1, arg2, arg3);
     }

--- a/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
+++ b/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
@@ -669,3 +669,36 @@ test_add(function() : Test("with-inst") constructor {
     instance_destroy(inst1);
     instance_destroy(inst2);
 });
+
+test_add(function() : Test("method-scope-vs-undefined") constructor {
+    var env = new CatspeakEnvironment();
+    var func = function(value) {
+        return value * 32;
+    }
+    env.interface.exposeFunction("func", func);
+    env.interface.exposeMethod("funcM", func);
+    
+    var ir = env.parseString(@'
+        func(0.5);
+    ');
+    
+    var gmlFuncA = env.compile(ir);
+	
+    ir = env.parseString(@'
+        funcM(0.5);
+    ');
+    
+    var gmlFuncB = env.compile(ir);
+    
+    var t = get_timer();
+    repeat(100000) {
+        gmlFuncA();	
+    }
+    show_debug_message("gmlFuncA (func) Time taken: " + string((get_timer() - t) / 1000) + "ms");
+    
+    t = get_timer();
+    repeat(100000) {
+        gmlFuncB();	
+    }
+    show_debug_message("gmlFuncB (funcM) Time taken: " + string((get_timer() - t) / 1000) + "ms");
+});

--- a/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
+++ b/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
@@ -669,3 +669,36 @@ test_add(function() : Test("with-inst") constructor {
     instance_destroy(inst1);
     instance_destroy(inst2);
 });
+
+test_add(function() : Test("method-scope-vs-undefined") constructor {
+	var env = new CatspeakEnvironment();
+	var func = function(value) {
+		return value * 32;
+	}
+	env.interface.exposeFunction("func", func);
+	env.interface.exposeMethod("funcM", func);
+	
+	var ir = env.parseString(@'
+        func(0.5);
+    ');
+	
+	var gmlFuncA = env.compile(ir);
+	
+	ir = env.parseString(@'
+        funcM(0.5);
+    ');
+	
+	var gmlFuncB = env.compile(ir);
+	
+	var t = get_timer();
+	repeat(100000) {
+		gmlFuncA();	
+	}
+	show_debug_message("gmlFuncA (func) Time taken: " + string((get_timer() - t) / 1000) + "ms");
+	
+	t = get_timer();
+	repeat(100000) {
+		gmlFuncB();	
+	}
+	show_debug_message("gmlFuncB (funcM) Time taken: " + string((get_timer() - t) / 1000) + "ms");
+});


### PR DESCRIPTION
Awhile ago I have tested in monthly that directly calling a method with a known scope is faster than using `with` and `script_execute_ext`. The only issue? LTS doesn't have `method_call` so I never brought it up.

Fast forward, I made a feature request as #120, and that got added in PR #129. Seeing how expr_call_0-3 has indeed given me a +10 FPS boost, I figured that I could squeeze out a little bit more. So I busted out my project, and experimented with some optimizations. Here's some keypoints:

- There was lines for fetching the method self, before using nullish coalesce on the shared self and globals.
- There was a call to fetching the current callee method
- We then execute and return the value of whatever is called.

After changing it so
- The method scope is checked to see if it's not undefined
- If it's not undefined, it will call the method and return the value
- If it's undefined, it will fallback the old routine (minus fetching the method scope, because we've already ruled it out at that stage).

I am presenting two analysises from a test case. One which I'll be providing to overview. The first test case was to see a "real world" estimate on how well it worked with a bunch of functions being utilized at once. Test Case 2 is the more "sane" and legitimate. But I am presenting both anyways as they do show performance off in different ways.

Test Case 1 - GMLspeak, in my own project (2024.6)
- 300 `obj_player` instances
- The functions used to compare are: `abs`, `angle_difference`, `point_direction`, `instance_find`, `irandom`, `irandom_range`.
- As these functions are essentially pure functions, I've gone ahead and given them a method scope to an empty struct. (Exposed with `exposeMethod`.) (Normally you wouldn't do this with *any* function, but in these rare cases, it actually helps estimate how much faster or slower it is)
- GMLspeak `self` access on all variables are also methods with a known scope (bounded to the environment itself), and are technically "pure", as they return from a `__gmlspeak_scopes` static struct.

Test Case 2 - Catspeak test case (with two separate loops of repeat, calling a variation with no method scope vs with a scope)
- A single local function, that takes a value and multiplies it by `32`, before returning it. (As native functions don't show off the full optimization benefits at times, and there's a small argument for pure functions needing their own separate optimizations in these cases)
- Ran on a loop of 100,000 for each call, one with no scope, and one with a scope. 
- The function return is not utilized at all (as it is purely used to show off the difference in performance)
- Rather than just checking on FPS (as these won't be called every frame but in a test framework), I have instead used a test case and printed out the time taken for both calls in milliseconds.
- `func` is the function with no scope. `funcM` is the function with a scope. (Exposed via `.exposeMethod`)
The test case for Test Case 2 is findable under `scr_testing_enviroment`, as `method-scope-vs-undefined`.

The results for Test Case 1:
VM: An additional +20 FPS increase has been noted (previously from 60 FPS, now 80 FPS)
YYC: An additional +120 FPS increase has been noted (previously from 140 FPS, now 260 FPS)

The Results for Test Case 2:
VM:
gmlFuncA (func) Time taken: 494.33ms
gmlFuncB (funcM) Time taken: 345.43ms

YYC:
gmlFuncA (func) Time taken: 210.29ms
gmlFuncB (funcM) Time taken: 81.39ms