### PR TITLE
Dev 3.1.1 - Added `params` and `params_count`

### DIFF
--- a/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
+++ b/src-lts/scripts/scr_catspeak_codegen/scr_catspeak_codegen.gml
@@ -633,7 +633,7 @@ function CatspeakGMLCompiler(ir, interface=undefined) constructor {
             program : undefined,
             locals : array_create(func.localCount),
             argCount : func.argCount,
-            args : array_create(argCount),
+            args : array_create(func.argCount),
             currentArgCount: 0,
         };
         ctx.program = __compileTerm(ctx, func.root);

--- a/src-lts/scripts/scr_catspeak_ir/scr_catspeak_ir.gml
+++ b/src-lts/scripts/scr_catspeak_ir/scr_catspeak_ir.gml
@@ -500,6 +500,39 @@ function CatspeakIRBuilder() constructor {
             property : property,
         });
     };
+    
+    /// Creates a params expression.
+    ///
+    /// @param {Struct} property
+    ///   The term containing the property to access.
+    ///
+    /// @param {Struct} key
+    ///   The term containing the key to access the collection with.
+    ///
+    /// @param {Real} [location]
+    ///   The source location of this term.
+    ///
+    /// @return {Struct}
+    static createParams = function (key, location=undefined) {
+        // __createTerm() will do argument validation
+        return __createTerm(CatspeakTerm.PARAMS, location, {
+            key : key,
+        });
+    };
+    
+    /// Creates a params expression.
+    ///
+    /// @param {Struct} property
+    ///   The term containing the property to access.
+    ///
+    /// @param {Real} [location]
+    ///   The source location of this term.
+    ///
+    /// @return {Struct}
+    static createParamsCount = function (location=undefined) {
+        // __createTerm() will do argument validation
+        return __createTerm(CatspeakTerm.PARAMS_COUNT, location, { });
+    };
 
     /// Creates a binary operator.
     ///
@@ -981,6 +1014,8 @@ enum CatspeakTerm {
     LOCAL,
     GLOBAL,
     FUNCTION,
+    PARAMS,
+    PARAMS_COUNT,
     SELF,
     /// @ignore
     __SIZE__

--- a/src-lts/scripts/scr_catspeak_lexer/scr_catspeak_lexer.gml
+++ b/src-lts/scripts/scr_catspeak_lexer/scr_catspeak_lexer.gml
@@ -147,8 +147,12 @@ enum CatspeakToken {
     ///
     /// @experimental
     PARAMS = 58,
+    /// The `params_count` keyword.
+    ///
+    /// @experimental
+    PARAMS_COUNT = 59,
     /// Represents a variable name.
-    IDENT = 59,
+    IDENT = 60,
     /// Represents a GML value. This could be one of:
     ///  - string literal:    `"hello world"`
     ///  - verbatim literal:  `@"\(0_0)/ no escapes!"`
@@ -157,22 +161,22 @@ enum CatspeakToken {
     ///  - character:         `'A'`, `'0'`, `'\n'`
     ///  - boolean:           `true` or `false`
     ///  - `undefined`
-    VALUE = 60,
+    VALUE = 61,
     /// Represents a sequence of non-breaking whitespace characters.
-    WHITESPACE = 61,
+    WHITESPACE = 62,
     /// Represents a comment.
-    COMMENT = 62,
+    COMMENT = 63,
     /// Represents the end of the file.
-    EOF = 63,
+    EOF = 64,
     /// Represents any other unrecognised character.
     ///
     /// @remark
     ///   If the compiler encounters a token of this type, it will typical
     ///   raise an exception. This likely indicates that a Catspeak script has
     ///   a syntax error somewhere.
-    OTHER = 64,
+    OTHER = 65,
     /// @ignore
-    __SIZE__ = 65,
+    __SIZE__ = 66,
 }
 
 /// @ignore

--- a/src-lts/scripts/scr_catspeak_lexer/scr_catspeak_lexer.gml
+++ b/src-lts/scripts/scr_catspeak_lexer/scr_catspeak_lexer.gml
@@ -147,12 +147,8 @@ enum CatspeakToken {
     ///
     /// @experimental
     PARAMS = 58,
-    /// The `params_count` keyword.
-    ///
-    /// @experimental
-    PARAMS_COUNT = 59,
     /// Represents a variable name.
-    IDENT = 60,
+    IDENT = 59,
     /// Represents a GML value. This could be one of:
     ///  - string literal:    `"hello world"`
     ///  - verbatim literal:  `@"\(0_0)/ no escapes!"`
@@ -161,20 +157,24 @@ enum CatspeakToken {
     ///  - character:         `'A'`, `'0'`, `'\n'`
     ///  - boolean:           `true` or `false`
     ///  - `undefined`
-    VALUE = 61,
+    VALUE = 60,
     /// Represents a sequence of non-breaking whitespace characters.
-    WHITESPACE = 62,
+    WHITESPACE = 61,
     /// Represents a comment.
-    COMMENT = 63,
+    COMMENT = 62,
     /// Represents the end of the file.
-    EOF = 64,
+    EOF = 63,
     /// Represents any other unrecognised character.
     ///
     /// @remark
     ///   If the compiler encounters a token of this type, it will typical
     ///   raise an exception. This likely indicates that a Catspeak script has
     ///   a syntax error somewhere.
-    OTHER = 65,
+    OTHER = 64,
+    /// The `params_count` keyword.
+    ///
+    /// @experimental
+    PARAMS_COUNT = 65,
     /// @ignore
     __SIZE__ = 66,
 }


### PR DESCRIPTION
This PR adds support for both `params` and `params_count` to the ir and compiler.
I haven't included any tests or modifications to the parser. Though I have thoroughly tested this between my own game project and during making this PR.

In my projects case, I've designed it in this way for the parser.
`params` is designed to be the same as GML `argument`, in that it cannot be used to pass the argument array to another. But it can be used to access the argument array. i.e. `params[key]`
`params_count` is designed to reflect the current `argument_count` status of  `__catspeak_function__` (via `currentArgCount`).

This would fulfil https://github.com/katsaii/catspeak-lang/issues/52.