### PR TITLE
Dev 3.1.2 - Added `catspeak_get_self` and `catspeak_get_index`

### DIFF
--- a/src-lts/scripts/scr_catspeak_environment/scr_catspeak_environment.gml
+++ b/src-lts/scripts/scr_catspeak_environment/scr_catspeak_environment.gml
@@ -1122,6 +1122,50 @@ function catspeak_method(self_, callee) {
     return method(self_, callee);
 }
 
+/// Returns the 'self' of the current method, either by returning the correct Catspeak scope
+/// or the exposed GML method scope (if any)
+/// 
+///
+/// @remark
+///   Preferred over 'method_get_self', otherwise you risk breaking your compiled
+///   Catspeak functions.
+///
+/// @param {Any} callee
+///  The function to get the current global context of. Can be a GML function,
+///  Catspeak function, or a function bound using `catspeak_method`.
+///
+/// @return {Any}
+function catspeak_get_self(callee) {
+    if (is_catspeak(callee)) {
+        var self_ = method_get_self(callee);
+        return self_[$ "self_"]; 
+    }
+    
+    return method_get_self(callee);
+}
+
+/// Returns the 'index' of the current method, either by returning the compiled 
+/// Catspeak function or the exposed GML function as a method bound to `undefined`
+/// 
+///
+/// @remark
+///   Preferred over 'method_get_index', otherwise you risk breaking your compiled
+///   Catspeak functions.
+///
+/// @param {Any} callee
+///  The function to get the current global context of. Can be a GML function,
+///  Catspeak function, or a function bound using `catspeak_method`.
+///
+/// @return {Any}
+function catspeak_get_index(callee) {
+    if (is_catspeak(callee)) {
+        var self_ = method_get_self(callee);
+        return self_[$ "callee"] ?? callee;
+    }
+    
+    return method(undefined, callee);
+}
+
 /// @ignore
 function __catspeak_function_method__() {
     static args = [];

--- a/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
+++ b/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
@@ -741,10 +741,14 @@ test_add(function() : Test("catspeak-get-index") constructor {
     assertEq(true, catspeak_get_index(speak) == speak);
     assertEq(true, catspeak_get_index(noInstSpeak) == speak);
     
+    var speakA = catspeak_get_index(instSpeak);
+    var speakB = catspeak_get_index(speak);
+    var speakC = catspeak_get_index(noInstSpeak);
+    
     // Should all return the correct name
-    assertEq(true, instSpeak() == "Elephant");
-    assertEq(true, speak() == "Rabbit");
-    assertEq(true, noInstSpeak() == "Rabbit");
+    assertEq(true, speakA() == "Rabbit");
+    assertEq(true, speakB() == "Rabbit");
+    assertEq(true, speakC() == "Rabbit");
 });
 
 test_add(function() : Test("while-loop") constructor {

--- a/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
+++ b/src-lts/scripts/scr_testing_environment/scr_testing_environment.gml
@@ -710,6 +710,43 @@ test_add(function() : Test("method-scope-vs-undefined") constructor {
     show_debug_message("gmlFuncB (funcM) Time taken: " + string((get_timer() - t) / 1000) + "ms");
 });
 
+test_add(function() : Test("catspeak-get-index") constructor {
+    var env = new CatspeakEnvironment();
+    
+    ir = env.parseString(@'
+        name = "Rabbit";
+        
+        speak = fun() {
+            return self.name;
+        };
+    ');
+    
+    var program = env.compile(ir);
+    program();
+    var globals = program.getGlobals();
+    var speak = globals.speak;
+    
+    var inst = {name: "Elephant"};
+    var instSpeak = catspeak_method(inst, speak); 
+    
+    var noInstSpeak = catspeak_method(undefined, instSpeak);
+    
+    // Only one should be a valid scope, rest is undefined
+    assertEq(true, catspeak_get_self(instSpeak) == inst);
+    assertEq(true, catspeak_get_self(speak) == undefined);
+    assertEq(true, catspeak_get_self(noInstSpeak) == undefined);
+    
+    // Should all be speak
+    assertEq(true, catspeak_get_index(instSpeak) == speak);
+    assertEq(true, catspeak_get_index(speak) == speak);
+    assertEq(true, catspeak_get_index(noInstSpeak) == speak);
+    
+    // Should all return the correct name
+    assertEq(true, instSpeak() == "Elephant");
+    assertEq(true, speak() == "Rabbit");
+    assertEq(true, noInstSpeak() == "Rabbit");
+});
+
 test_add(function() : Test("while-loop") constructor {
     var env = new CatspeakEnvironment();
     


### PR DESCRIPTION
This PR introduces `catspeak_get_self` and `catspeak_get_index`, which play as counterparts to `method_get_self` and `method_get_index`. The reason for this is that `method_get_index` will return `__catspeak_function__` or `__catspeak_method__` from Catspeak programs. And even then, not as a method but as a GML function index. That's likely to cause all sorts of issues.
`method_get_self` also has the unfortunate issue where it *could* return the Catspeak program struct itself. Which may also be unintended depending on who you ask.

`catspeak_get_index` resolves this by **always** returning a method. Never a function ID. This means that any Catspeak functions or Catspeak methods, will always return their callee program "as is". And any GML function will be returned as a method with a bound to `undefined`.

`catspeak_get_self` resolves this by returning self from *only* GML functions and Catspeak methods. Anything marked as a Catspeak function (via `is_catspeak`) will retrieve `self_` via accessor (if it exists), or returns `undefined`.